### PR TITLE
added specialized tokenizer for original languages

### DIFF
--- a/src/__tests__/tokenizers/tokenizers.test.js
+++ b/src/__tests__/tokenizers/tokenizers.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import {tokenize} from '../..';
+import {tokenize, tokenizeOrigLang} from '../..';
 
 describe('Tokenizer', function() {
   it('tokenize() should return ["asdf"] array for "asdf" text', function() {
@@ -96,10 +96,11 @@ describe('tokenizeWithPunctuation', function() {
     const expected = ['କାରଣ', 'ଈଶ୍ୱର', 'ଦୂତମାନଙ୍କ', 'ମଧ୍ୟରୁ', 'କାହାକୁ', 'କେବେ', 'ଏହା', 'କହିଅଛନ୍ତି', ',', '"', 'ତୁମ୍ଭେ', 'ଆମ୍ଭର', 'ପୁତ୍ର', ',', 'ଆଜି', 'ଆମ୍ଭେ', 'ତୁମ୍ଭକୁ', 'ଜନ୍ମ', 'ଦେଇଅଛୁ', '?', '\'', '\'', 'ପୁନଶ୍ଚ', ',', '"', 'ଆମ୍ଭେ', 'ତାହାଙ୍କର', 'ପିତା', 'ହେବା', ',', 'ଆଉ', 'ସେ', 'ଆମ୍ଭର', 'ପୁତ୍ର', 'ହେବେ', '?', '\'', '\''];
     expect(tokens).toEqual(expected);
   });
-  // it('should handle punctuation in mga text including apostrophe as contraction or the like.', function() {
-  //   const text = "Sapagkat sino sa mga anghel ang pinagsabihan niya kailanman ng, \"Ikaw ay aking anak, ngayon ako ay naging iyong ama?\" At muli, \"Ako'y magiging ama sa kaniya, at siya ay magiging anak sa akin\"?";
-  //   const tokens = tokenize({text, includePunctuation: true});
-  //   const expected = ["Sapagkat", "sino", "sa", "mga", "anghel", "ang", "pinagsabihan", "niya", "kailanman", "ng", ",", "\"", "Ikaw", "ay", "aking", "anak", ",", "ngayon", "ako", "ay", "naging", "iyong", "ama", "?", "\"", "At", "muli", ",", "\"", "Ako'y", "magiging", "ama", "sa", "kaniya", ",", "at", "siya", "ay", "magiging", "anak", "sa", "akin", "\"", "?"];
-  //   expect(tokens).toEqual(expected);
-  // });
+
+  it('should handle punctuation in greek text', function() {
+    const text = 'ἀλλ’ οὐ προκόψουσιν ἐπὶ πλεῖον, ἡ γὰρ ἄνοια αὐτῶν ἔκδηλος ἔσται πᾶσιν, ὡς καὶ ἡ ἐκείνων ἐγένετο.';
+    const tokens = tokenizeOrigLang({text, includePunctuation: true});
+    const expected = ['ἀλλ’', 'οὐ', 'προκόψουσιν', 'ἐπὶ', 'πλεῖον', ',', 'ἡ', 'γὰρ', 'ἄνοια', 'αὐτῶν', 'ἔκδηλος', 'ἔσται', 'πᾶσιν', ',', 'ὡς', 'καὶ', 'ἡ', 'ἐκείνων', 'ἐγένετο', '.'];
+    expect(tokens).toEqual(expected);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {
   tokenize,
+  tokenizeOrigLang,
   word,
   punctuation,
   whitespace,
@@ -25,6 +26,7 @@ import {
 
 export {
   tokenize,
+  tokenizeOrigLang,
   normalizer,
   normalizerDestructive,
   normalizationsDestructive,

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -65,7 +65,7 @@ export const tokenize = ({
     number: greedyNumber,
   };
   const _parsers = greedy ? greedyParsers : parsers;
-  delete _parsers['greedyWord'];
+  delete _parsers.greedyWord;
   let tokens = classifyTokens(string, _parsers, 'unknown');
   const types = [];
   if (includeWords) types.push('word');

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -1,20 +1,38 @@
 import xRegExp from 'xregexp';
-import { occurrenceInTokens, occurrencesInTokens } from './occurrences';
-import { normalizer, normalizerDestructive, normalizationsDestructive } from './normalizers';
+import {occurrenceInTokens, occurrencesInTokens} from './occurrences';
+import {normalizer, normalizerDestructive} from './normalizers';
+
 // constants
 export const _word = '[\\pL\\pM\\u200D\\u2060]+';
+// TRICKY: original languages do not use single quotes so u2019 is considered part of a word
+export const _origWord = '[\\pL\\pM\\u200D\\u2060\\u2019]+';
 export const _number = '[\\pN\\pNd\\pNl\\pNo]+';
 export const _wordOrNumber = '(' + _word + '|' + _number + ')';
+export const _origWordOrNumber = '(' + _origWord + '|' + _number + ')';
 export const _greedyWord = '(' + _wordOrNumber + '([-\'’]' + _word + ')+|' + _word + '’?)';
+export const _origGreedyWord = '(' + _origWordOrNumber + '([-\'’]' + _origWord + ')+|' + _origWord + '’?)';
 export const _greedyNumber = '(' + _number + '([:.,]?' + _number + ')+|' + _number + ')';
 export const word = xRegExp(_word, '');
+export const origWord = xRegExp(_origWord, '');
 export const greedyWord = xRegExp(_greedyWord, '');
+export const origGreedyWord = xRegExp(_origGreedyWord, '');
 export const punctuation = xRegExp('(^\\p{P}|[<>]{2})', '');
 export const whitespace = /\s+/;
 export const number = xRegExp(_number);
 export const greedyNumber = xRegExp(_greedyNumber); //  /(\d+([:.,]?\d)+|\d+)/;
 export const number_ = xRegExp(number);
 
+
+export const tokenizeOrigLang = (params) => tokenize({
+  parsers: {
+    word: origWord,
+    greedyWord: origGreedyWord,
+    whitespace,
+    punctuation,
+    number,
+  },
+  ...params,
+});
 
 /**
  * Tokenize a string into an array of words
@@ -31,9 +49,8 @@ export const tokenize = ({
   greedy = false,
   verbose = false,
   occurrences = false,
-  parsers = { word, whitespace, punctuation, number },
+  parsers = {word, greedyWord, whitespace, punctuation, number},
   normalize = false,
-  //normalizations = normalizationsDestructive,
   normalizations = null,
 }) => {
   let string = text.slice(0);
@@ -42,8 +59,13 @@ export const tokenize = ({
     string = normalizerDestructive(string, normalizations);
   }
 
-  const greedyParsers = { ...parsers, word: greedyWord, number: greedyNumber };
+  const greedyParsers = {
+    ...parsers,
+    word: parsers.greedyWord,
+    number: greedyNumber,
+  };
   const _parsers = greedy ? greedyParsers : parsers;
+  delete _parsers['greedyWord'];
   let tokens = classifyTokens(string, _parsers, 'unknown');
   const types = [];
   if (includeWords) types.push('word');
@@ -56,7 +78,7 @@ export const tokenize = ({
     tokens = tokens.map((token, index) => {
       const _occurrences = occurrencesInTokens(tokens, token.token);
       const _occurrence = occurrenceInTokens(tokens, index, token.token);
-      return { ...token, occurrence: _occurrence, occurrences: _occurrences };
+      return {...token, occurrence: _occurrence, occurrences: _occurrences};
     });
   }
   if (verbose) {


### PR DESCRIPTION
see https://github.com/unfoldingWord/translationCore/issues/7156

Adds a specialized method for tokenizing original languages. This is just a light wrapper around the regular tokenize method, that adds a custom word parser.

The key difference between original languages and other languages is that original languages do not use single quotes, therefore we will consider them (specifically `u2019`) as an apostrophe every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/string-punctuation-tokenizer/73)
<!-- Reviewable:end -->
